### PR TITLE
Migrate to OAuth2 filter v3

### DIFF
--- a/envoy/envoy.yaml
+++ b/envoy/envoy.yaml
@@ -26,7 +26,7 @@ static_resources:
           http_filters:
           - name: envoy.filters.http.oauth2
             typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.http.oauth2.v3alpha.OAuth2
+              "@type": type.googleapis.com/envoy.extensions.filters.http.oauth2.v3.OAuth2
               config:
                 token_endpoint:
                   cluster: google-oauth2-token


### PR DESCRIPTION
The following error occurred, so I fixed it.
```
[2022-01-28 18:32:50.010][1][critical][main] [source/server/server.cc:117] error initializing configuration '/etc/envoy/envoy.yaml': Unable to parse JSON as proto (INVALID_ARGUMENT:(http_filters[0].typed_config): invalid value Invalid type URL, unknown type: envoy.extensions.filters.http.oauth2.v3alpha.OAuth2 for type Any):
```
There seems to be a change in the type that needs to be specified.
https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/oauth2_filter